### PR TITLE
Fix error where items are not loaded when data changes before promise resolves

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -22,7 +22,7 @@ type Props = {
    * Callback to load more items.
    * Receives a parameter `'start'` or `'end'` to load items at the start or end.
    */
-  loadMoreItems: (direction: Direction) => Promise<unknown>;
+  loadMoreItems: (direction: Direction) => Promise<unknown> | unknown;
   /**
    * Callback to be called when items have been rendered.
    * This prop is optional.

--- a/package/src/InfiniteScroll.tsx
+++ b/package/src/InfiniteScroll.tsx
@@ -1,8 +1,10 @@
 import {ReactNode, useCallback, useEffect, useLayoutEffect, useRef} from 'react';
 import {ListOnItemsRenderedProps} from 'react-window';
+import {isPromise} from './util';
 
 type OnItemsRendered = (props: ListOnItemsRenderedProps) => unknown;
 type Direction = 'start' | 'end';
+// [NOTE] Make sure to update README!
 type Props = {
   /** Return whether an item at the index has been loaded. */
   isItemLoaded: (index: number) => boolean;
@@ -10,7 +12,7 @@ type Props = {
    * Callback to load more items.
    * Receives a parameter `'start'` or `'end'` to load items at the start or end.
    */
-  loadMoreItems: (direction: Direction) => Promise<unknown>;
+  loadMoreItems: (direction: Direction) => Promise<unknown> | unknown;
   /**
    * Callback to be called when items have been rendered.
    * This prop is optional.
@@ -80,7 +82,10 @@ const InfiniteScroll = ({
     if (direction === 'start') {
       prevHeight.current = outerElement.scrollHeight;
     }
-    await loadMoreItems(direction);
+    const ret = loadMoreItems(direction);
+    if (isPromise(ret)) {
+      await ret;
+    }
     pending.current = false;
   }, [getOuterElement, loadMoreItems, scrollOffset]);
 

--- a/package/src/util.ts
+++ b/package/src/util.ts
@@ -1,0 +1,10 @@
+export const isPromise = (param: unknown): param is Promise<unknown> => {
+  if (!param) {
+    return false;
+  }
+  const convertedParam = param as Promise<unknown>;
+  if (typeof convertedParam.then === 'function') {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
Allow `loadMoreItems` prop return non-`promise` values.
If return values are not `promise`, then do not call `await` to set `pending.current` to `false` instantly.
If the values are `promise`, then `await` them. It is still crucial to block excessively calling `loadMoreItems`.

closes #11.