### PR TITLE
[#13] Fix errors `loadMoreItems` not work if rerendering runs before the promise resolves

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -126,6 +126,43 @@ In another case, where you have as many rows as the infinite scrolling component
 even though you have tiny (too tiny!) scrollable height.
 Data change event will help load more items in that case.
 
+## `loadMoreItems` is getting called too many/few times.
+There maybe several bugs and issues with the package.
+Some possible issues with the component are that it may call `loadMoreItems` too many times,
+or that it may not call `loadMoreItems`.
+
+One feasible reason why it calls `loadMoreItems` too many times is that
+`loadMoreItems` does not *await* until `data` changes and return.
+This is because react-window-infinite-scroll tries to prevent excessive `loadMoreItems` calls for performance,
+by waiting for `loadMoreItems` to finish one at a time.<br>
+Even if `loadMoreItems` finishes earlier than `data` changes,
+the package might not notice it and call `loadMoreItems` and recall once more when `data` changes.
+If `loadMoreItems` has something to do with `promise`s,
+*wait* for the responses and update the `data`. Please do not exit right after making API calls
+since it can lead to undefined behaviors.
+
+```jsx
+// Please don't do this ✖️
+const loadMoreItems = () => {
+  fetchFromRemote().then((response) => {
+    setData(data => [...data, response]);
+  });
+};
+
+// Or this ✖️
+const loadMoreItems = () => {
+  fetchFromRemote((response) => {
+    setData(data => [...data, response]);
+  });
+};
+
+// Please do this ✔️
+const loadMoreItems = async () => {
+  const response = await fetchFromRemote();
+  setData(data => [...data, response]);
+};
+```
+
 # Changelog
 ## v0.0.3
 - Fix an error where `outerRef` has `null` or `undefined` value.

--- a/package/src/InfiniteScroll.tsx
+++ b/package/src/InfiniteScroll.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, useCallback, useEffect, useLayoutEffect, useRef} from 'react';
+import {ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {ListOnItemsRenderedProps} from 'react-window';
 import {isPromise} from './util';
 
@@ -56,12 +56,15 @@ const InfiniteScroll = ({
   /** To prevent call loadMoreItems redundantly, in both `onItemsRendered` and on data change. */
   const pending = useRef<boolean>(false);
   const prevHeight = useRef<number | null>(null);
+  /** A dummy state to trigger rerender when promises by `loadMoreItems` resolves. */
+  const [dummyState, setDummyState] = useState(0);
+  const forceRerender = () => setDummyState(pre => pre + 1);
   /**
    * Prevent calling `loadMoreItems` frequently when loading items at the start.
    * However, do this only if enough items are loaded that
    * the `outerRef`'s scrollHeight is large enough to scroll the element.
    */
-  const shouldBlockLoadMoreItems = useRef<number | null>(null);
+  const shouldBlockLoadMoreItems = useRef<ReturnType<typeof setTimeout> | null>(null);
   const getOuterElement = useCallback(() =>
     !outerRef ?
       null :
@@ -87,6 +90,7 @@ const InfiniteScroll = ({
       await ret;
     }
     pending.current = false;
+    forceRerender();
   }, [getOuterElement, loadMoreItems, scrollOffset]);
 
   const _onItemsRendered = useCallback<OnItemsRendered>((args) => {
@@ -122,7 +126,7 @@ const InfiniteScroll = ({
       // Scrolled to top.
       _loadMoreItems('start');
     }
-  }, [data, isItemLoaded, itemCount, scrollOffset, _loadMoreItems, getOuterElement]);
+  }, [data, dummyState, isItemLoaded, itemCount, scrollOffset, _loadMoreItems, getOuterElement]);
 
   // Scroll downward to prevent calling loadMoreItems infinitely.
   // Do not pass deps argument as the effect should run with ref value.


### PR DESCRIPTION
closes #13.