### PR TITLE
Fix items are not loaded from start due to un-resetted value

### DIFF
--- a/package/src/InfiniteScroll.tsx
+++ b/package/src/InfiniteScroll.tsx
@@ -117,8 +117,8 @@ const InfiniteScroll = ({
       return;
     }
     const element = outerElement;
-    const isAtBottom = element.scrollTop + element.offsetHeight + scrollOffset >= element.scrollHeight;
-    const isAtTop = element.scrollTop <= scrollOffset;
+    const isAtBottom = element.scrollTop + element.offsetHeight + scrollOffset > element.scrollHeight;
+    const isAtTop = element.scrollTop < scrollOffset;
     if (isAtBottom && !isItemLoaded(data.length)) {
       // Scrolled to bottom.
       _loadMoreItems('end');
@@ -147,6 +147,8 @@ const InfiniteScroll = ({
     return () => {
       if (shouldBlockLoadMoreItems.current !== null) {
         clearTimeout(shouldBlockLoadMoreItems.current);
+        // Need to reset the value because the function may return early and does not reassign.
+        shouldBlockLoadMoreItems.current = null;
       }
     };
   });


### PR DESCRIPTION
The `useLayoutEffect` may return early and does not reassign `shouldBlockLoadMoreItems`.

```tsx
    if (prevHeight.current === null || outerElement === null) {
      return;
    }
```

Then, `shouldBlockLoadMoreItems` is not `null`,and if `loadedEnoughItems` is `true` because there are enough items, `loadMoreItems` will never execute.
```tsx
    const loadedEnoughItems = outerElement.clientHeight + scrollOffset < outerElement.scrollHeight;
```

~Reset `shouldBlockLoadMoreItems` when its timeout is cleared.~

~But the change incurred infinite `loadMoreItems`. This is because `shouldBlockLoadMoreItems` is now almost meaningless.
Most of the times, the value is `null`. Thus tighten the range to determine whether the scroll is at the top/bottom.~

---

Here is a better way; instead of making `shouldBlockLoadMoreItems` meaningless, setTimeout before returning inside `useLayoutEffect`. In this way I can keep `shouldBlockLoadMoreItems` and prevent not loading items on scroll.

```tsx
    if (prevHeight.current === null || outerElement === null) {
      if (shouldBlockLoadMoreItems.current !== null) {
        shouldBlockLoadMoreItems.current = setTimeout(() => {
          shouldBlockLoadMoreItems.current = null;
        }, TIMEOUT_INTERVAL);
      }
      return () => {
        if (shouldBlockLoadMoreItems.current !== null) {
          clearTimeout(shouldBlockLoadMoreItems.current);
        }
      };
    }
```