### PR TITLE
Improve test code stability

### DIFF
--- a/package/test/InfiniteScroll.test.tsx
+++ b/package/test/InfiniteScroll.test.tsx
@@ -95,6 +95,9 @@ test('Load more longer items synchronously with initial data', async ({mount}) =
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -120,6 +123,9 @@ test('Load more longer items synchronously without initial data', async ({mount}
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -145,6 +151,9 @@ test('Load more longer items asynchronously but instantly with initial data', as
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -170,6 +179,9 @@ test('Load more longer items asynchronously but instantly without initial data',
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -195,6 +207,9 @@ test('Load more longer items asynchronously but fast with initial data', async (
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -220,6 +235,9 @@ test('Load more longer items asynchronously but fast without initial data', asyn
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -245,6 +263,9 @@ test('Load more longer items asynchronously but slowly with initial data', async
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);
@@ -270,6 +291,9 @@ test('Load more longer items asynchronously but slowly without initial data', as
   await expect(component).toContainText('0');
   await expect(component).toContainText('1');
   await expect(component).toContainText('2');
+  await expect(component).toContainText('7');
+  await expect(component).toContainText('8');
+  await expect(component).toContainText('9');
 
   await expect(component).not.toContainText('14');
   await scrollComponentToBottom(component);


### PR DESCRIPTION
This is because playwright might wait for 9 to appear without even having waited 3. Playwright has default timeout 5s for each expect.

For instance:
```
Error: Timed out 5000ms waiting for expect(received).toContainText(expected)

Expected string: "10"
Received string: "0123456789"
Call log:
  - expect.toContainText with timeout 5000ms
  - waiting for locator('#root').locator('internal:control=component')
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "012"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "012"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "012"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "0123"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "012345"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "012345678"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "0123456789"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "0123456789"
  -   locator resolved to <div class="Outer">…</div>
  -   unexpected value "0123456789"
```

![test output](https://github.com/dlguswo333/react-window-infinite-scroll/assets/61929981/e8537e71-0d5a-4394-a4e8-416c3c26ee8d)