### PR TITLE
[#34] Fix preview deploy github action fails

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -39,7 +39,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
-      - run: npm run build -w preview
+      - run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact


### PR DESCRIPTION
>[commonjs--resolver] Failed to resolve entry for package "react-window-infinite-scroll". The package may have incorrect main/module/exports specified in its package.json.

This may be due to not building 'package' before building 'preview'.