### PR TITLE
[#34] Run preview deploy github action regardless of paths

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -5,7 +5,6 @@ on:
   # Runs on pushes targeting the default branch and preview folder
   push:
     branches: ["main"]
-    paths: ["preview"]
 
   # Allows you to run this workflow manually from the Actions tab
   # This event will only trigger a workflow run if the workflow file is on the default branch.


### PR DESCRIPTION
I thought it wrong and preview pages should be updated even though 'preview' folder is not updated.
If the infinite scroll package is updated, then the preview pages should also be updated.