### PR TITLE
Fix some tests fail on Webkit due to ambiguous texts

### DIFF
--- a/package/test/Components.tsx
+++ b/package/test/Components.tsx
@@ -12,7 +12,7 @@ declare global {
 }
 
 export const StaticData1 = () => {
-  const data = ['0'];
+  const data = ['<0>'];
   const outerRef = useRef<HTMLElement>(null);
   const loadMoreItems = () => new Promise(res => res(undefined));
   const isItemsLoaded = () => true;
@@ -45,7 +45,7 @@ export const StaticData1 = () => {
 };
 
 export const StaticData2 = () => {
-  const data = ['0', '1', '2'];
+  const data = ['<0>', '<1>', '<2>'];
   const outerRef = useRef<HTMLElement>(null);
   const loadMoreItems = () => new Promise(res => res(undefined));
   const isItemsLoaded = () => true;
@@ -83,16 +83,16 @@ export const StaticData2 = () => {
  */
 export const SimpleDynamicData = ({hasInitialData, howToLoad, longerData}: {hasInitialData: boolean; howToLoad: 'sync' | 'instantAsync' | 'fastAsync' | 'slowAsync', longerData: boolean;}) => {
   const maxDataSize = longerData ? 100 : 3;
-  const [data, setData] = useState<string[]>(hasInitialData ? ['0'] : []);
+  const [data, setData] = useState<string[]>(hasInitialData ? ['<0>'] : []);
   const outerRef = useRef<HTMLElement>(null);
   const loadMoreItemsSync = () => {
-    setData(data.concat(data.length.toString()));
+    setData(data.concat(`<${data.length.toString()}>`));
   };
   const loadMoreItemsAsync = async () => {
     if (howToLoad !== 'instantAsync') {
       await new Promise(res => setTimeout(res, howToLoad === 'fastAsync' ? 0 : 300));
     }
-    setData(data.concat(data.length.toString()));
+    setData(data.concat(`<${data.length.toString()}>`));
   };
   const isItemsLoaded = (index: number) => {
     const ret = !(index === data.length && index < maxDataSize);
@@ -132,12 +132,12 @@ export const SimpleDynamicData = ({hasInitialData, howToLoad, longerData}: {hasI
  */
 export const BiDirectDynamicData = ({hasInitialData, howToLoad}: {hasInitialData: boolean; howToLoad: 'sync' | 'instantAsync' | 'fastAsync' | 'slowAsync'}) => {
   const maxDataSize = 100;
-  const [data, setData] = useState<string[]>(hasInitialData ? ['0'] : []);
+  const [data, setData] = useState<string[]>(hasInitialData ? ['<0>'] : []);
   const outerRef = useRef<HTMLElement>(null);
   const getNewData = (direction: 'start' | 'end') => (
     direction === 'start' ?
-      [`${Number(data[0]) - 1}`, ...data] :
-      [...data, data.length === 0 ? '0' : `${Number(data[data.length - 1]) + 1}`]
+      [`<${Number(data[0].replace(/[<>]/g, '')) - 1}>`, ...data] :
+      [...data, data.length === 0 ? '<0>' : `<${Number(data[data.length - 1].replace(/[<>]/g, '')) + 1}>`]
   );
   const loadMoreItemsSync = (direction: 'start' | 'end') => {
     setData(getNewData(direction));
@@ -192,20 +192,20 @@ export const BiDirectDynamicData = ({hasInitialData, howToLoad}: {hasInitialData
  */
 export const SomeFailDynamicData = ({hasInitialData, howToLoad}: {hasInitialData: boolean; howToLoad: 'sync' | 'async';}) => {
   const maxDataSize = 100;
-  const [data, setData] = useState<string[]>(hasInitialData ? ['0'] : []);
+  const [data, setData] = useState<string[]>(hasInitialData ? ['<0>'] : []);
   const outerRef = useRef<HTMLElement>(null);
   const loadMoreItemsSync = () => {
     if (!shouldUpdateData) {
       return;
     }
-    setData(data.concat(data.length.toString()));
+    setData(data.concat(`<${data.length.toString()}>`));
   };
   const [shouldUpdateData, setShouldUpdateData] = useState(false);
   const loadMoreItemsAsync = async () => {
     if (!shouldUpdateData) {
       return;
     }
-    setData(data.concat(data.length.toString()));
+    setData(data.concat(`<${data.length.toString()}>`));
   };
 
   useEffect(() => {

--- a/package/test/InfiniteScroll.test.tsx
+++ b/package/test/InfiniteScroll.test.tsx
@@ -24,345 +24,345 @@ const getData = (component: Awaited<ReturnType<ComponentFixtures['mount']>>) => 
 
 test('With static data with initial data', async ({mount}) => {
   const component = await mount(<StaticData1 />);
-  await expect(component).toContainText('0');
+  await expect(component).toContainText('<0>');
 });
 
 test('With static data without initial data', async ({mount}) => {
   const component = await mount(<StaticData2 />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items synchronously with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='sync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items synchronously without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='sync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items asynchronously but instantly with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='instantAsync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items asynchronously but instantly without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='instantAsync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items asynchronously but fast with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='fastAsync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items asynchronously but fast without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='fastAsync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items asynchronously but slowly with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='slowAsync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more items asynchronously but slowly without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='slowAsync' longerData={false} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 });
 
 test('Load more longer items synchronously with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='sync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items synchronously without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='sync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items asynchronously but instantly with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='instantAsync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items asynchronously but instantly without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='instantAsync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items asynchronously but fast with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='fastAsync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items asynchronously but fast without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='fastAsync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items asynchronously but slowly with initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={true} howToLoad='slowAsync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more longer items asynchronously but slowly without initial data', async ({mount}) => {
   const component = await mount(<SimpleDynamicData hasInitialData={false} howToLoad='slowAsync' longerData={true} />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).toContainText('7');
-  await expect(component).toContainText('8');
-  await expect(component).toContainText('9');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).toContainText('<7>');
+  await expect(component).toContainText('<8>');
+  await expect(component).toContainText('<9>');
 
-  await expect(component).not.toContainText('14');
+  await expect(component).not.toContainText('<14>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('10');
+  await expect(component).toContainText('<10>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('11');
+  await expect(component).toContainText('<11>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('12');
+  await expect(component).toContainText('<12>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('13');
+  await expect(component).toContainText('<13>');
   await scrollComponentToBottom(component);
 
-  await expect(component).toContainText('14');
+  await expect(component).toContainText('<14>');
   await scrollComponentToBottom(component);
 });
 
 test('Load more items bidirectionally, asynchronously but fast without initial data', async ({mount}) => {
   const component = await mount(<BiDirectDynamicData hasInitialData={false} howToLoad='fastAsync' />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
-  await expect(component).not.toContainText('-2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).not.toContainText('<-2>');
 
   await scrollComponentToBottom(component);
-  await expect(component).toContainText('10');
-  await expect(getData(component)).resolves.toContain('10');
+  await expect(component).toContainText('<10>');
+  await expect(getData(component)).resolves.toContain('<10>');
 
   await scrollComponentToBottom(component);
-  await expect(component).toContainText('11');
-  await expect(getData(component)).resolves.toContain('11');
+  await expect(component).toContainText('<11>');
+  await expect(getData(component)).resolves.toContain('<11>');
 
   await scrollComponentToBottom(component);
-  await expect(component).toContainText('12');
-  await expect(getData(component)).resolves.toContain('12');
+  await expect(component).toContainText('<12>');
+  await expect(getData(component)).resolves.toContain('<12>');
 
   await scrollComponentToBottom(component);
-  await expect(component).toContainText('13');
-  await expect(getData(component)).resolves.toContain('13');
+  await expect(component).toContainText('<13>');
+  await expect(getData(component)).resolves.toContain('<13>');
 
   await scrollComponentToBottom(component);
-  await expect(component).toContainText('14');
-  await expect(getData(component)).resolves.toContain('14');
+  await expect(component).toContainText('<14>');
+  await expect(getData(component)).resolves.toContain('<14>');
 
   await scrollComponentToTop(component);
-  await expect(component).toContainText('-1');
-  await expect(getData(component)).resolves.toContain('-1');
+  await expect(component).toContainText('<-1>');
+  await expect(getData(component)).resolves.toContain('<-1>');
 
   await scrollComponentToTop(component);
-  await expect(component).toContainText('-2');
-  await expect(getData(component)).resolves.toContain('-2');
+  await expect(component).toContainText('<-2>');
+  await expect(getData(component)).resolves.toContain('<-2>');
 
   await scrollComponentToTop(component);
-  await expect(component).toContainText('-3');
-  await expect(getData(component)).resolves.toContain('-3');
+  await expect(component).toContainText('<-3>');
+  await expect(getData(component)).resolves.toContain('<-3>');
 
   await scrollComponentToTop(component);
-  await expect(component).toContainText('-4');
-  await expect(getData(component)).resolves.toContain('-4');
+  await expect(component).toContainText('<-4>');
+  await expect(getData(component)).resolves.toContain('<-4>');
 });
 
 test('Loading data synchronously, but fails for the first period without initial data', async ({mount}) => {
   const component = await mount(<SomeFailDynamicData hasInitialData={false} howToLoad='sync' />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 
   for (let value = 10; value <= 20;++value) {
     await scrollComponentToBottom(component);
@@ -372,9 +372,9 @@ test('Loading data synchronously, but fails for the first period without initial
 
 test('Loading data asynchronously, but fails for the first period without initial data', async ({mount}) => {
   const component = await mount(<SomeFailDynamicData hasInitialData={false} howToLoad='async' />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 
   for (let value = 10; value <= 20;++value) {
     await scrollComponentToBottom(component);
@@ -384,9 +384,9 @@ test('Loading data asynchronously, but fails for the first period without initia
 
 test('Loading data synchronously, but fails for the first period with initial data', async ({mount}) => {
   const component = await mount(<SomeFailDynamicData hasInitialData={true} howToLoad='sync' />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 
   for (let value = 10; value <= 20;++value) {
     await scrollComponentToBottom(component);
@@ -396,9 +396,9 @@ test('Loading data synchronously, but fails for the first period with initial da
 
 test('Loading data asynchronously, but fails for the first period with initial data', async ({mount}) => {
   const component = await mount(<SomeFailDynamicData hasInitialData={true} howToLoad='async' />);
-  await expect(component).toContainText('0');
-  await expect(component).toContainText('1');
-  await expect(component).toContainText('2');
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
 
   for (let value = 10; value <= 20;++value) {
     await scrollComponentToBottom(component);


### PR DESCRIPTION
The test component just renders sequential numbers `0`, `1`, `2`, and so on,
and the tests check if the component contains each number.
But when checking two digit numbers, for instance `12`, it might grab `1` and `2` together and mark it successful.
That is wrong behavior.
While chromium and firefox browsers did not catch that, webkit somehow caught it and mark it failed.
It might be because webkit did not load more items unlike the others, after falsely checking `12` is rendered correctly.

![image](https://github.com/user-attachments/assets/d7249376-9769-4b8f-8588-8c47fa1bdcab)

Wrap each number in curly brackets as it will act as a kind of **barrier** between each number.