### PR TITLE
[#41] Fix start direction infinite scroll not work when threshold is 0

### DIFF
--- a/package/src/InfiniteScroll.tsx
+++ b/package/src/InfiniteScroll.tsx
@@ -102,10 +102,16 @@ const InfiniteScroll = ({
       // All items are loaded and visible.
       return;
     }
-    if (visibleStopIndex >= data.length - threshold && !isItemLoaded(data.length)) {
+    if (
+      visibleStopIndex >= data.length - threshold &&
+      !isItemLoaded(data.length)
+    ) {
       // Last 'threshold' items are visible.
       _loadMoreItems('end');
-    } else if (visibleStartIndex <= threshold - 1 && !isItemLoaded(-1)) {
+    } else if (
+      (visibleStartIndex <= threshold - 1 || visibleStartIndex === 0) &&
+      !isItemLoaded(-1)
+    ) {
       // First 'threshold' items are visible.
       _loadMoreItems('start');
     }

--- a/package/test/Components.tsx
+++ b/package/test/Components.tsx
@@ -247,3 +247,56 @@ export const SomeFailDynamicData = ({hasInitialData, howToLoad}: {hasInitialData
     </FixedSizeList>}
   </InfiniteScroll>;
 };
+
+/**
+ * Should load more data even if `threshold` is 0, thanks to positive `scrollOffset`.
+ */
+export const ThresholdZeroBiDirectDynamicData = () => {
+  const maxDataSize = 100;
+  const [data, setData] = useState<string[]>(['<0>']);
+  const outerRef = useRef<HTMLElement>(null);
+  const getNewData = (direction: 'start' | 'end') => (
+    direction === 'start' ?
+      [`<${Number(data[0].replace(/[<>]/g, '')) - 1}>`, ...data] :
+      [...data, data.length === 0 ? '<0>' : `<${Number(data[data.length - 1].replace(/[<>]/g, '')) + 1}>`]
+  );
+  const loadMoreItemsAsync = async (direction: 'start' | 'end') => {
+    await new Promise(res => setTimeout(res, 0));
+    setData(getNewData(direction));
+  };
+  const isItemsLoaded = (index: number) => {
+    const ret = !(index < maxDataSize && (index === -1 || index === data.length));
+    return ret;
+  };
+  const itemCount = data.length + (data.length < maxDataSize ? 1 : 0);
+
+  const Row = ({index, style}: {index: number, style: CSSProperties}) => (
+    <div style={style}>{data[index]}</div>
+  );
+
+  useEffect(() => {
+    window.data = data;
+  }, [data]);
+
+  return <InfiniteScroll
+    data={data}
+    loadMoreItems={loadMoreItemsAsync}
+    isItemLoaded={isItemsLoaded}
+    itemCount={itemCount}
+    threshold={0}
+    outerRef={outerRef}
+    scrollOffset={40}
+  >
+    {({onItemsRendered}) => <FixedSizeList
+      height={300}
+      itemCount={itemCount}
+      width='100%'
+      onItemsRendered={onItemsRendered}
+      itemSize={30}
+      outerRef={outerRef}
+      className='Outer'
+    >
+      {Row}
+    </FixedSizeList>}
+  </InfiniteScroll>;
+};

--- a/package/test/InfiniteScroll.test.tsx
+++ b/package/test/InfiniteScroll.test.tsx
@@ -1,5 +1,5 @@
 import {test, expect, ComponentFixtures} from '@playwright/experimental-ct-react17';
-import {StaticData1, StaticData2, SimpleDynamicData, BiDirectDynamicData, SomeFailDynamicData} from './Components';
+import {StaticData1, StaticData2, SimpleDynamicData, BiDirectDynamicData, SomeFailDynamicData, ThresholdZeroBiDirectDynamicData} from './Components';
 import React from 'react';
 
 test.use({viewport: {width: 1000, height: 1000}});
@@ -404,4 +404,48 @@ test('Loading data asynchronously, but fails for the first period with initial d
     await scrollComponentToBottom(component);
     await expect(component).toContainText(value.toString());
   }
+});
+
+test('Loading data asynchronously, but zero threshold and positive scrollOffset', async ({mount}) => {
+  const component = await mount(<ThresholdZeroBiDirectDynamicData />);
+  await expect(component).toContainText('<0>');
+  await expect(component).toContainText('<1>');
+  await expect(component).toContainText('<2>');
+  await expect(component).not.toContainText('<-2>');
+
+  await scrollComponentToBottom(component);
+  await expect(component).toContainText('<10>');
+  await expect(getData(component)).resolves.toContain('<10>');
+
+  await scrollComponentToBottom(component);
+  await expect(component).toContainText('<11>');
+  await expect(getData(component)).resolves.toContain('<11>');
+
+  await scrollComponentToBottom(component);
+  await expect(component).toContainText('<12>');
+  await expect(getData(component)).resolves.toContain('<12>');
+
+  await scrollComponentToBottom(component);
+  await expect(component).toContainText('<13>');
+  await expect(getData(component)).resolves.toContain('<13>');
+
+  await scrollComponentToBottom(component);
+  await expect(component).toContainText('<14>');
+  await expect(getData(component)).resolves.toContain('<14>');
+
+  await scrollComponentToTop(component);
+  await expect(component).toContainText('<-1>');
+  await expect(getData(component)).resolves.toContain('<-1>');
+
+  await scrollComponentToTop(component);
+  await expect(component).toContainText('<-2>');
+  await expect(getData(component)).resolves.toContain('<-2>');
+
+  await scrollComponentToTop(component);
+  await expect(component).toContainText('<-3>');
+  await expect(getData(component)).resolves.toContain('<-3>');
+
+  await scrollComponentToTop(component);
+  await expect(component).toContainText('<-4>');
+  await expect(getData(component)).resolves.toContain('<-4>');
 });


### PR DESCRIPTION
Closes #41 .
If `visibleStartIndex` is `0`, it means the first item appears inside the window and it is time to load more items.
