### PR TITLE
[#52] Fix jumping scroll position when loading more items at the start

### DIFF
--- a/package/src/InfiniteScroll.tsx
+++ b/package/src/InfiniteScroll.tsx
@@ -184,11 +184,11 @@ const InfiniteScroll = ({
 
     if (layout === 'vertical') {
       outerElement.scrollTop = Math.max(
-        outerElement.scrollHeight - prevLength.current, scrollOffset
+        outerElement.scrollTop + outerElement.scrollHeight - prevLength.current, scrollOffset
       );
     } else {
       outerElement.scrollLeft = Math.max(
-        outerElement.scrollWidth - prevLength.current, scrollOffset
+        outerElement.scrollLeft + outerElement.scrollWidth - prevLength.current, scrollOffset
       );
     }
     prevLength.current = null;


### PR DESCRIPTION
Closes #52 .

I tried to add test cases for this issue but I could not do it reliably since it's hard to catch the moment between scrolled to the start and loaded new data.