### PR TITLE
Lock react-window to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5451,10 +5451,11 @@
       }
     },
     "node_modules/react-window": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
-      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": ">=3.1.1 <6"
@@ -5463,8 +5464,8 @@
         "node": ">8.0.0"
       },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-window-infinite-scroll": {
@@ -6366,7 +6367,7 @@
         "postcss": "^8.4.30",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-window": "^1.8.10",
+        "react-window": "^1.8.11",
         "rollup": "^3.29.4",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-typescript2": "^0.35.0",

--- a/package/package.json
+++ b/package/package.json
@@ -47,6 +47,7 @@
   },
   "peerDependencies": {
     "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "react-dom": ">=17.0.0",
+    "react-window": "^1.8.11"
   }
 }

--- a/package/package.json
+++ b/package/package.json
@@ -38,7 +38,7 @@
     "postcss": "^8.4.30",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-window": "^1.8.10",
+    "react-window": "^1.8.11",
     "rollup": "^3.29.4",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-typescript2": "^0.35.0",


### PR DESCRIPTION
react-window v2 came out but the package is not compatible with it (It doesn't export `FixedSizeList`).
So let's fix the version to v1.